### PR TITLE
Update att_indirizzo_v1.0.0.xsd

### DIFF
--- a/to_moduli/examples/data_model_organization/02_attributi/att_indirizzo_v1.0.0.xsd
+++ b/to_moduli/examples/data_model_organization/02_attributi/att_indirizzo_v1.0.0.xsd
@@ -14,8 +14,8 @@
     </xs:simpleType>    
     
     <xs:simpleType name="numero_civico_stype">
-        <xs:restriction base="xs:integer">
-            <xs:minExclusive value="0"/>
+       <xs:restriction base="xs:string">
+            <xs:minExclusive value="1"/>
         </xs:restriction>
     </xs:simpleType>
     


### PR DESCRIPTION
Il numero civico non è detto che sia composto solo da interi: spesso ci sono associate lettere, esempio 1/A